### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/iddrisulatif244/461e558a-8ff2-4a1b-acc5-5f19a0874a2e/78af51b4-7d23-4832-8a22-20152c5c4c02/_apis/work/boardbadge/f6887076-267a-4542-900e-97a4cc35f2bb)](https://dev.azure.com/iddrisulatif244/461e558a-8ff2-4a1b-acc5-5f19a0874a2e/_boards/board/t/78af51b4-7d23-4832-8a22-20152c5c4c02/Microsoft.RequirementCategory)
 # Arrowhead


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/iddrisulatif244/461e558a-8ff2-4a1b-acc5-5f19a0874a2e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.